### PR TITLE
Improve tooltip styling and unify hints

### DIFF
--- a/components/AiFeatures.tsx
+++ b/components/AiFeatures.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback } from 'react';
 import type { Category, SelectedTag } from '../types';
 import { Icon } from './icons';
+import { Tooltip } from './Tooltip';
 
 interface AiFeaturesProps {
     category: Category;
@@ -161,17 +162,19 @@ Here is a perfect example of the required response format:
                                 >
                                     Generate Lyrics
                                 </button>
-                                <button 
-                                    onClick={() => handleCopy(idea, 'idea', i)} 
-                                    className="p-1.5 rounded-md hover:bg-bunker-200 dark:hover:bg-bunker-700 transition-colors"
-                                    title="Copy idea to clipboard"
-                                >
-                                    {copiedIdeaIndex === i ? (
-                                        <Icon name="check" className="w-4 h-4 text-green-500" />
-                                    ) : (
-                                        <Icon name="copy" className="w-4 h-4 text-bunker-500 dark:text-bunker-400" />
-                                    )}
-                                </button>
+                                <Tooltip text={copiedIdeaIndex === i ? 'Copied!' : 'Copy idea to clipboard'}>
+                                    <button
+                                        onClick={() => handleCopy(idea, 'idea', i)}
+                                        className="p-1.5 rounded-md hover:bg-bunker-200 dark:hover:bg-bunker-700 transition-colors"
+                                        aria-label="Copy idea to clipboard"
+                                    >
+                                        {copiedIdeaIndex === i ? (
+                                            <Icon name="check" className="w-4 h-4 text-green-500" />
+                                        ) : (
+                                            <Icon name="copy" className="w-4 h-4 text-bunker-500 dark:text-bunker-400" />
+                                        )}
+                                    </button>
+                                </Tooltip>
                             </div>
                         </div>
                     ))}
@@ -195,17 +198,19 @@ Here is a perfect example of the required response format:
                                 value={generatedLyrics}
                                 className="w-full h-64 p-3 bg-white dark:bg-bunker-900 border border-bunker-200 dark:border-bunker-700 rounded-lg text-bunker-900 dark:text-white placeholder-bunker-400 dark:placeholder-bunker-500 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y font-mono text-xs"
                             />
-                             <button 
-                                onClick={() => handleCopy(generatedLyrics, 'full')} 
-                                className="absolute top-2 right-2 p-1.5 rounded-md bg-bunker-100 hover:bg-bunker-200 dark:bg-bunker-800 dark:hover:bg-bunker-700 transition-colors"
-                                title="Copy lyrics to clipboard"
-                            >
-                                {copiedLyrics ? (
-                                    <Icon name="check" className="w-4 h-4 text-green-500" />
-                                ) : (
-                                    <Icon name="copy" className="w-4 h-4 text-bunker-500 dark:text-bunker-400" />
-                                )}
-                            </button>
+                             <Tooltip text={copiedLyrics ? 'Copied!' : 'Copy lyrics to clipboard'}>
+                                <button
+                                    onClick={() => handleCopy(generatedLyrics, 'full')}
+                                    className="absolute top-2 right-2 p-1.5 rounded-md bg-bunker-100 hover:bg-bunker-200 dark:bg-bunker-800 dark:hover:bg-bunker-700 transition-colors"
+                                    aria-label="Copy lyrics to clipboard"
+                                >
+                                    {copiedLyrics ? (
+                                        <Icon name="check" className="w-4 h-4 text-green-500" />
+                                    ) : (
+                                        <Icon name="copy" className="w-4 h-4 text-bunker-500 dark:text-bunker-400" />
+                                    )}
+                                </button>
+                             </Tooltip>
                         </div>
                     )}
                 </div>

--- a/components/LogPanel.tsx
+++ b/components/LogPanel.tsx
@@ -5,6 +5,7 @@ import { useLocalStorage } from '../hooks/useLocalStorage';
 import { logger } from '../utils/logger';
 import type { LogLevel, LogEntry } from '../types';
 import { Icon } from './icons';
+import { Tooltip } from './Tooltip';
 
 interface LogPanelProps {
   onClose: () => void;
@@ -86,17 +87,35 @@ export const LogPanel: React.FC<LogPanelProps> = ({ onClose }) => {
                     <input type="checkbox" checked={logToFile} onChange={e => setLogToFile(e.target.checked)} className="h-4 w-4 rounded border-bunker-300 text-blue-600 focus:ring-blue-500" />
                     <span>Log to File</span>
                 </label>
-                <button onClick={handleOpenLocation} className="flex items-center space-x-1 text-sm px-2 py-1 rounded-md bg-bunker-100 dark:bg-bunker-800 hover:bg-bunker-200 dark:hover:bg-bunker-700" title="Open Log Location">
+                <Tooltip text="Open log location">
+                  <button
+                    onClick={handleOpenLocation}
+                    className="flex items-center space-x-1 text-sm px-2 py-1 rounded-md bg-bunker-100 dark:bg-bunker-800 hover:bg-bunker-200 dark:hover:bg-bunker-700"
+                    aria-label="Open log location"
+                  >
                     <Icon name="folder" className="w-4 h-4" />
-                </button>
+                  </button>
+                </Tooltip>
             </>
           )}
-          <button onClick={handleClear} className="flex items-center space-x-1 text-sm px-2 py-1 rounded-md bg-bunker-100 dark:bg-bunker-800 hover:bg-bunker-200 dark:hover:bg-bunker-700" title="Clear Logs">
-             <Icon name="trash" className="w-4 h-4" />
-          </button>
-          <button onClick={onClose} className="p-1 rounded-full hover:bg-bunker-100 dark:hover:bg-bunker-800" title="Close Panel">
-            <Icon name="x" className="w-5 h-5 text-bunker-500" />
-          </button>
+          <Tooltip text="Clear logs">
+            <button
+              onClick={handleClear}
+              className="flex items-center space-x-1 text-sm px-2 py-1 rounded-md bg-bunker-100 dark:bg-bunker-800 hover:bg-bunker-200 dark:hover:bg-bunker-700"
+              aria-label="Clear logs"
+            >
+              <Icon name="trash" className="w-4 h-4" />
+            </button>
+          </Tooltip>
+          <Tooltip text="Close panel">
+            <button
+              onClick={onClose}
+              className="p-1 rounded-full hover:bg-bunker-100 dark:hover:bg-bunker-800"
+              aria-label="Close panel"
+            >
+              <Icon name="x" className="w-5 h-5 text-bunker-500" />
+            </button>
+          </Tooltip>
         </div>
       </header>
       <div ref={logContainerRef} className="flex-grow p-2 overflow-y-auto font-mono text-xs">

--- a/components/PresetsGalleryPanel.tsx
+++ b/components/PresetsGalleryPanel.tsx
@@ -403,9 +403,16 @@ const PresetCard: React.FC<PresetCardProps> = ({ preset, taxonomy, callLlm, cate
                                     onBlur={handleRename}
                                     className="form-input w-full text-sm py-1 pr-9"
                                 />
-                                <button onClick={handleGenerateTitles} disabled={isGeneratingTitles} className="absolute inset-y-0 right-0 flex items-center pr-2 text-bunker-400 hover:text-blue-500 disabled:opacity-50" title="Generate names with AI">
-                                    {isGeneratingTitles ? <LoadingSpinner /> : <Icon name="wandSparkles" className="w-4 h-4" />}
-                                </button>
+                                <Tooltip text={isGeneratingTitles ? 'Generating names…' : 'Generate names with AI'}>
+                                    <button
+                                        onClick={handleGenerateTitles}
+                                        disabled={isGeneratingTitles}
+                                        className="absolute inset-y-0 right-0 flex items-center pr-2 text-bunker-400 hover:text-blue-500 disabled:opacity-50"
+                                        aria-label="Generate names with AI"
+                                    >
+                                        {isGeneratingTitles ? <LoadingSpinner /> : <Icon name="wandSparkles" className="w-4 h-4" />}
+                                    </button>
+                                </Tooltip>
                             </div>
                             {titleError && <p className="text-xs text-red-500 mt-1">{titleError}</p>}
                             {aiTitles.length > 0 && (

--- a/components/SavePresetModal.tsx
+++ b/components/SavePresetModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Icon } from './icons';
+import { Tooltip } from './Tooltip';
 import { normalizeTagLabels } from '../utils/normalization';
 import type { SelectedTag, Category, Taxonomy, Tag } from '../types';
 
@@ -134,9 +135,16 @@ export const SavePresetModal: React.FC<SavePresetModalProps> = ({
                 className="form-input w-full pr-10"
                 autoFocus
               />
-              <button onClick={handleGenerateTitles} disabled={isGenerating} className="absolute inset-y-0 right-0 flex items-center pr-3 text-bunker-400 hover:text-blue-500 disabled:opacity-50" title="Generate names with AI">
+              <Tooltip text={isGenerating ? 'Generating names…' : 'Generate names with AI'}>
+                <button
+                  onClick={handleGenerateTitles}
+                  disabled={isGenerating}
+                  className="absolute inset-y-0 right-0 flex items-center pr-3 text-bunker-400 hover:text-blue-500 disabled:opacity-50"
+                  aria-label="Generate names with AI"
+                >
                   {isGenerating ? <LoadingSpinner /> : <Icon name="wandSparkles" className="w-5 h-5" />}
-              </button>
+                </button>
+              </Tooltip>
             </div>
             {generationError && <p className="text-xs text-red-500 mt-1">{generationError}</p>}
             {aiTitles.length > 0 && (

--- a/components/StatusBar.tsx
+++ b/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { AiStatus } from '../types';
 import { Icon } from './icons';
+import { Tooltip } from './Tooltip';
 
 interface StatusBarProps {
   appVersion: string;
@@ -18,10 +19,12 @@ const AiStatusIndicator: React.FC<{ status: AiStatus }> = ({ status }) => {
   const { color, text } = statusMap[status];
 
   return (
-    <div className="flex items-center space-x-2" title={text}>
-      <div className={`w-2.5 h-2.5 rounded-full ${color}`} />
-      <span className="text-xs hidden sm:inline">{text}</span>
-    </div>
+    <Tooltip text={text}>
+      <div className="flex items-center space-x-2">
+        <div className={`w-2.5 h-2.5 rounded-full ${color}`} />
+        <span className="text-xs hidden sm:inline">{text}</span>
+      </div>
+    </Tooltip>
   );
 };
 
@@ -34,14 +37,18 @@ export const StatusBar: React.FC<StatusBarProps> = ({ appVersion, tagCount, conf
         <span>Designed by Tim Sinaeve</span>
       </div>
       <div className="flex items-center space-x-4">
-        <div className="flex items-center space-x-1.5" title="Selected Tags">
-          <Icon name="tag" className="w-4 h-4" />
-          <span>{tagCount}</span>
-        </div>
-        <div className={`flex items-center space-x-1.5 transition-colors ${conflictCount > 0 ? 'text-red-500 dark:text-red-400' : ''}`} title="Tag Conflicts">
-          <Icon name="warning" className="w-4 h-4" />
-          <span>{conflictCount}</span>
-        </div>
+        <Tooltip text="Selected Tags">
+          <div className="flex items-center space-x-1.5">
+            <Icon name="tag" className="w-4 h-4" />
+            <span>{tagCount}</span>
+          </div>
+        </Tooltip>
+        <Tooltip text="Tag Conflicts">
+          <div className={`flex items-center space-x-1.5 transition-colors ${conflictCount > 0 ? 'text-red-500 dark:text-red-400' : ''}`}>
+            <Icon name="warning" className="w-4 h-4" />
+            <span>{conflictCount}</span>
+          </div>
+        </Tooltip>
         <AiStatusIndicator status={aiStatus} />
       </div>
     </footer>

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -136,8 +136,13 @@ export const Tooltip: React.FC<TooltipProps> = ({ children, text, placement = 'b
     <div
       ref={tooltipRef}
       role="tooltip"
-      style={{ top: `${position.top}px`, left: `${position.left}px`, opacity: opacity }}
-      className="fixed w-max max-w-xs p-2.5 bg-white dark:bg-bunker-900 border border-bunker-200 dark:border-bunker-800 text-bunker-900 dark:text-bunker-100 text-xs rounded-lg shadow-lg z-50 transition-opacity duration-200"
+      style={{
+        top: `${position.top}px`,
+        left: `${position.left}px`,
+        opacity,
+        transform: `scale(${0.96 + opacity * 0.04})`,
+      }}
+      className="fixed pointer-events-none w-max max-w-sm px-3 py-2 bg-white/95 dark:bg-bunker-900/95 border border-bunker-200/70 dark:border-bunker-700/70 text-bunker-800 dark:text-bunker-100 text-sm font-medium leading-snug rounded-xl shadow-2xl backdrop-blur-sm whitespace-pre-line z-50 transition-all duration-200"
     >
       {text}
     </div>,
@@ -146,13 +151,13 @@ export const Tooltip: React.FC<TooltipProps> = ({ children, text, placement = 'b
 
   return (
     <>
-      <div 
-        ref={triggerRef} 
-        onMouseEnter={handleMouseEnter} 
-        onMouseLeave={hideTooltip} 
-        onFocus={handleMouseEnter} 
-        onBlur={hideTooltip} 
-        className="flex items-center"
+      <div
+        ref={triggerRef}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={hideTooltip}
+        onFocus={handleMouseEnter}
+        onBlur={hideTooltip}
+        className="inline-flex items-center"
       >
         {children}
       </div>


### PR DESCRIPTION
## Summary
- restyle the shared Tooltip component for a modern, consistent appearance and smoother animation
- replace native title hints with the Tooltip component across status, AI features, presets, and log views
- ensure hint-triggering controls have accessible labels while preventing clipping or overflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd82ea9aa0833291c62b229dbbf07e