### PR TITLE
feat: support svg-driven icon pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `package.json` file is already configured with the necessary scripts and set
     -   `npm run package-win`: Creates a Windows installer (`.exe`).
 -   **`build`**: This section configures `electron-builder`.
 
-*Note: For custom application icons, you can create an `assets` directory with `icon.ico` (Windows), `icon.icns` (Mac), and `icon.png` (Linux), then add an `icon` property to the respective OS settings in the `build` section of `package.json`.*
+*Icon pipeline:* place a single SVG (e.g. `assets/app-icon.svg`) in the project. The build script validates the SVG and rasterises it into platform assets automatically. If the SVG is missing or cannot be processed, a procedural fallback icon is generated. The resulting Windows (`.ico`), macOS (`.icns`), and Linux (`.png`) assets are saved to `dist/icons` and referenced by the Electron Builder configuration.
 
 ## 3. How to Run
 

--- a/assets/app-icon.svg
+++ b/assets/app-icon.svg
@@ -1,0 +1,36 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">UDIO Prompt Crafter Icon</title>
+  <desc id="desc">Geometric sound wave emblem with layered gradients representing creative audio prompts.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1B1F3B" />
+      <stop offset="50%" stop-color="#2E2F66" />
+      <stop offset="100%" stop-color="#3A88F4" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="65%">
+      <stop offset="0%" stop-color="#8FE7FF" stop-opacity="0.9" />
+      <stop offset="55%" stop-color="#3778FF" stop-opacity="0.4" />
+      <stop offset="100%" stop-color="#050B2E" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="wave" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#FF9A9E" />
+      <stop offset="50%" stop-color="#FAD0C4" />
+      <stop offset="100%" stop-color="#F6D365" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="url(#bg)" />
+  <circle cx="256" cy="220" r="200" fill="url(#glow)" />
+  <g transform="translate(96 180)">
+    <path d="M16 152c32-48 64-72 96-72s64 24 96 24 64-24 96-72l0 128c-32 48-64 72-96 72s-64-24-96-24-64 24-96 72z" fill="#0B1029" opacity="0.35" />
+    <path d="M0 140c28-44 56-66 84-66s56 22 84 22 56-22 84-66l0 116c-28 44-56 66-84 66s-56-22-84-22-56 22-84 66z" fill="url(#wave)" />
+  </g>
+  <g transform="translate(140 180)" fill="#ffffff" opacity="0.9">
+    <rect x="12" y="0" width="28" height="152" rx="14" />
+    <rect x="72" y="32" width="28" height="152" rx="14" />
+    <rect x="132" y="16" width="28" height="152" rx="14" />
+    <rect x="192" y="48" width="28" height="152" rx="14" />
+  </g>
+  <path d="M156 356c26 24 60 36 100 36s74-12 100-36" fill="none" stroke="#8FE7FF" stroke-width="18" stroke-linecap="round" opacity="0.6" />
+  <circle cx="256" cy="180" r="32" fill="#FDF2FF" opacity="0.85" />
+  <circle cx="256" cy="180" r="18" fill="#FF7A7A" />
+</svg>

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,8 +1,184 @@
 const esbuild = require('esbuild');
 const path = require('path');
 const fs = require('fs');
+const { spawn } = require('child_process');
+const { executeAppBuilderAsJson } = require('app-builder-lib/out/util/appBuilder');
+const { generateFallbackPngs } = require('./utils/iconRasterizer');
+
+const electronBinary = require('electron');
 
 const distDir = 'dist';
+const assetsDir = 'assets';
+const iconBaseName = 'app-icon';
+
+const fallbackSvg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Fallback Creative Audio Icon</title>
+  <desc id="desc">Abstract gradient badge used when a custom icon is not supplied.</desc>
+  <defs>
+    <linearGradient id="fallback-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1F1C2C" />
+      <stop offset="50%" stop-color="#3A1C71" />
+      <stop offset="100%" stop-color="#D76D77" />
+    </linearGradient>
+    <linearGradient id="fallback-wave" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#FCE38A" />
+      <stop offset="50%" stop-color="#F38181" />
+      <stop offset="100%" stop-color="#EAFFD0" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="128" fill="url(#fallback-bg)" />
+  <g transform="translate(96 156)">
+    <path d="M0 180c28-48 56-72 84-72s56 24 84 24 56-24 84-72l0 144c-28 48-56 72-84 72s-56-24-84-24-56 24-84 72z" fill="#120C1C" opacity="0.35" />
+    <path d="M16 168c28-44 56-66 84-66s56 22 84 22 56-22 84-66l0 124c-28 44-56 66-84 66s-56-22-84-22-56 22-84 66z" fill="url(#fallback-wave)" />
+  </g>
+  <g transform="translate(152 180)" fill="#FFFFFF" opacity="0.9">
+    <rect x="0" y="0" width="28" height="152" rx="14" />
+    <rect x="56" y="32" width="28" height="152" rx="14" />
+    <rect x="112" y="16" width="28" height="152" rx="14" />
+    <rect x="168" y="48" width="28" height="152" rx="14" />
+  </g>
+  <circle cx="256" cy="164" r="30" fill="#FFFFFF" opacity="0.85" />
+  <circle cx="256" cy="164" r="18" fill="#FFD166" />
+</svg>`;
+
+function validateSvg(content) {
+  if (typeof content !== 'string') {
+    return false;
+  }
+  const trimmed = content.trim();
+  return trimmed.startsWith('<svg') && trimmed.endsWith('</svg>');
+}
+
+async function generateRasterIcons(svgPath) {
+  const tempSvgPath = path.resolve(distDir, `${iconBaseName}.svg`);
+  const svgContent = fs.readFileSync(svgPath, 'utf8');
+  fs.writeFileSync(tempSvgPath, svgContent, 'utf8');
+
+  const rasterDir = path.resolve(distDir, 'icons', 'png');
+  fs.mkdirSync(rasterDir, { recursive: true });
+
+  try {
+    await new Promise((resolve, reject) => {
+      const child = spawn(electronBinary, [path.join(__dirname, 'scripts', 'icon-generator.js'), tempSvgPath, rasterDir], {
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+        stdio: 'inherit',
+      });
+      child.on('exit', (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`Icon rasterisation failed with exit code ${code}`));
+        }
+      });
+    });
+    return rasterDir;
+  } catch (error) {
+    console.warn('⚠️  SVG rasterisation via Electron failed, generating fallback PNGs procedurally.', error.message);
+    generateFallbackPngs(rasterDir);
+    return rasterDir;
+  }
+}
+
+async function convertWithAppBuilder(format, inputPath, outputDir) {
+  const normalizedInput = path.resolve(inputPath);
+  const normalizedOutput = path.resolve(outputDir);
+  const args = ['icon', '--format', format, '--out', normalizedOutput];
+  const stats = fs.statSync(normalizedInput);
+  if (stats.isDirectory()) {
+    const files = fs.readdirSync(normalizedInput)
+      .filter(file => file.toLowerCase().endsWith('.png'))
+      .map(file => path.join(normalizedInput, file))
+      .sort((a, b) => {
+        const sizeA = parseInt(path.basename(a).split('-')[1], 10) || 0;
+        const sizeB = parseInt(path.basename(b).split('-')[1], 10) || 0;
+        return sizeA - sizeB;
+      });
+    const minSize = format === 'ico' ? 256 : format === 'icns' ? 512 : 16;
+    const filtered = files.filter(file => {
+      const size = parseInt(path.basename(file).split('-')[1], 10) || 0;
+      return size >= minSize;
+    });
+    if (filtered.length === 0) {
+      throw new Error(`No PNG files found in ${normalizedInput} to convert to ${format}.`);
+    }
+    for (const file of filtered) {
+      args.push('--input', file);
+    }
+  } else {
+    args.push('--input', normalizedInput);
+  }
+
+  const result = await executeAppBuilderAsJson(args);
+
+  if (result.error) {
+    throw new Error(result.error);
+  }
+
+  return result.icons || [];
+}
+
+async function prepareIcons() {
+  const iconOutputDir = path.resolve(distDir, 'icons');
+  fs.mkdirSync(iconOutputDir, { recursive: true });
+
+  let svgSourcePath = null;
+  if (fs.existsSync(assetsDir)) {
+    const svgFiles = fs.readdirSync(assetsDir).filter(file => file.toLowerCase().endsWith('.svg'));
+    const preferred = svgFiles.find(file => file.toLowerCase() === `${iconBaseName}.svg`);
+    const chosen = preferred || svgFiles[0];
+    if (chosen) {
+      const candidatePath = path.join(assetsDir, chosen);
+      const content = fs.readFileSync(candidatePath, 'utf8');
+      if (validateSvg(content)) {
+        svgSourcePath = candidatePath;
+      } else {
+        console.warn(`⚠️  Invalid SVG markup detected in ${candidatePath}. Using fallback icon.`);
+      }
+    }
+  }
+
+  if (!svgSourcePath) {
+    svgSourcePath = path.resolve(distDir, `${iconBaseName}-fallback.svg`);
+    fs.writeFileSync(svgSourcePath, fallbackSvg, 'utf8');
+  }
+
+  const rasterDir = await generateRasterIcons(svgSourcePath);
+
+  const icoDir = path.join(iconOutputDir, 'ico');
+  const icnsDir = path.join(iconOutputDir, 'icns');
+  fs.mkdirSync(icoDir, { recursive: true });
+  fs.mkdirSync(icnsDir, { recursive: true });
+
+  await convertWithAppBuilder('ico', rasterDir, icoDir);
+  await convertWithAppBuilder('icns', rasterDir, icnsDir);
+
+  const generatedIco = path.join(icoDir, 'icon.ico');
+  const desiredIco = path.join(icoDir, `${iconBaseName}.ico`);
+  if (fs.existsSync(generatedIco)) {
+    fs.renameSync(generatedIco, desiredIco);
+  }
+
+  const generatedIcns = path.join(icnsDir, 'icon.icns');
+  const desiredIcns = path.join(icnsDir, `${iconBaseName}.icns`);
+  if (fs.existsSync(generatedIcns)) {
+    fs.renameSync(generatedIcns, desiredIcns);
+  }
+
+  const png512 = path.join(iconOutputDir, 'icon.png');
+  const sourcePng = path.join(rasterDir, 'icon-512.png');
+  if (fs.existsSync(sourcePng)) {
+    fs.copyFileSync(sourcePng, png512);
+  }
+
+  return {
+    svg: svgSourcePath,
+    pngDir: rasterDir,
+    ico: fs.existsSync(desiredIco) ? desiredIco : generatedIco,
+    icns: fs.existsSync(desiredIcns) ? desiredIcns : generatedIcns,
+    png: png512,
+  };
+}
 
 async function build() {
     // Clean dist directory
@@ -25,6 +201,8 @@ async function build() {
 
     // Copy index.html
     fs.copyFileSync('index.html', path.join(distDir, 'index.html'));
+
+    const iconPaths = await prepareIcons();
 
     // Build React App
     await esbuild.build({
@@ -61,6 +239,7 @@ async function build() {
     });
 
     console.log('⚡ Build complete! ⚡');
+    console.log('🖼️  Icon assets prepared at:', iconPaths);
 }
 
 build().catch((err) => {

--- a/package.json
+++ b/package.json
@@ -43,20 +43,25 @@
       }
     ],
     "directories": {
-      "output": "release"
+      "output": "release",
+      "buildResources": "dist/icons"
     },
+    "icon": "dist/icons/icon.png",
     "win": {
-      "target": "nsis"
+      "target": "nsis",
+      "icon": "dist/icons/ico/app-icon.ico"
     },
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true
     },
     "mac": {
-      "target": "dmg"
+      "target": "dmg",
+      "icon": "dist/icons/icns/app-icon.icns"
     },
     "linux": {
-      "target": "AppImage"
+      "target": "AppImage",
+      "icon": "dist/icons/icon.png"
     }
   }
 }

--- a/scripts/icon-generator.js
+++ b/scripts/icon-generator.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const { nativeImage } = require('electron');
+
+function exitWithError(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+const [, , svgPath, outputDir, sizesArg] = process.argv;
+
+if (!svgPath || !outputDir) {
+  exitWithError('Usage: icon-generator <svgPath> <outputDir> [sizes]');
+}
+
+if (!fs.existsSync(svgPath)) {
+  exitWithError(`Icon generator could not find SVG file at ${svgPath}`);
+}
+
+const svgContent = fs.readFileSync(svgPath);
+const image = nativeImage.createFromBuffer(svgContent);
+
+if (image.isEmpty()) {
+  exitWithError('Failed to create image from SVG content.');
+}
+
+const sizes = sizesArg ? sizesArg.split(',').map(v => parseInt(v, 10)).filter(Boolean) : [16, 24, 32, 48, 64, 128, 256, 512, 1024];
+
+fs.mkdirSync(outputDir, { recursive: true });
+
+for (const size of sizes) {
+  const resized = image.resize({ width: size, height: size, quality: 'best' });
+  const buffer = resized.toPNG();
+  fs.writeFileSync(path.join(outputDir, `icon-${size}.png`), buffer);
+}

--- a/utils/iconRasterizer.js
+++ b/utils/iconRasterizer.js
@@ -1,0 +1,237 @@
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+
+const bgStops = [
+  { t: 0, color: [0x1B, 0x1F, 0x3B] },
+  { t: 0.5, color: [0x2E, 0x2F, 0x66] },
+  { t: 1, color: [0x3A, 0x88, 0xF4] },
+];
+
+const waveStops = [
+  { t: 0, color: [0xFF, 0x9A, 0x9E] },
+  { t: 0.5, color: [0xFA, 0xD0, 0xC4] },
+  { t: 1, color: [0xF6, 0xD3, 0x65] },
+];
+
+const glowColor = [0x8F, 0xE7, 0xFF];
+const shadowColor = [0x0B, 0x10, 0x29];
+const barColor = [0xFF, 0xFF, 0xFF];
+const accentOuter = [0xFD, 0xF2, 0xFF];
+const accentInner = [0xFF, 0x7A, 0x7A];
+
+const crcTable = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buf) {
+  let crc = 0xFFFFFFFF;
+  for (let i = 0; i < buf.length; i++) {
+    crc = crcTable[(crc ^ buf[i]) & 0xFF] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+function createChunk(type, data) {
+  const chunk = Buffer.alloc(8 + data.length + 4);
+  chunk.writeUInt32BE(data.length, 0);
+  chunk.write(type, 4, 4, 'ascii');
+  data.copy(chunk, 8);
+  const crc = crc32(chunk.subarray(4, 8 + data.length));
+  chunk.writeUInt32BE(crc, 8 + data.length);
+  return chunk;
+}
+
+function createPng(width, height, rgbaBuffer) {
+  const signature = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // color type RGBA
+  ihdr[10] = 0; // compression method
+  ihdr[11] = 0; // filter method
+  ihdr[12] = 0; // interlace method
+
+  const stride = width * 4;
+  const scanlines = Buffer.alloc((stride + 1) * height);
+  for (let y = 0; y < height; y++) {
+    const lineStart = y * (stride + 1);
+    scanlines[lineStart] = 0; // filter type 0
+    rgbaBuffer.copy(scanlines, lineStart + 1, y * stride, y * stride + stride);
+  }
+
+  const compressed = zlib.deflateSync(scanlines, { level: 9 });
+  const chunks = [
+    createChunk('IHDR', ihdr),
+    createChunk('IDAT', compressed),
+    createChunk('IEND', Buffer.alloc(0)),
+  ];
+
+  return Buffer.concat([signature, ...chunks]);
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function sampleGradient(stops, t) {
+  if (t <= stops[0].t) return stops[0].color;
+  if (t >= stops[stops.length - 1].t) return stops[stops.length - 1].color;
+  for (let i = 0; i < stops.length - 1; i++) {
+    const current = stops[i];
+    const next = stops[i + 1];
+    if (t >= current.t && t <= next.t) {
+      const localT = (t - current.t) / (next.t - current.t);
+      return [
+        Math.round(lerp(current.color[0], next.color[0], localT)),
+        Math.round(lerp(current.color[1], next.color[1], localT)),
+        Math.round(lerp(current.color[2], next.color[2], localT)),
+      ];
+    }
+  }
+  return stops[stops.length - 1].color;
+}
+
+function blend(base, overlay, alpha) {
+  const inv = 1 - alpha;
+  return [
+    Math.round(base[0] * inv + overlay[0] * alpha),
+    Math.round(base[1] * inv + overlay[1] * alpha),
+    Math.round(base[2] * inv + overlay[2] * alpha),
+  ];
+}
+
+function insideRoundedRect(x, y, size, radius) {
+  const maxIndex = size - 1;
+  const r = radius;
+  if (x >= r && x <= maxIndex - r) return true;
+  if (y >= r && y <= maxIndex - r) return true;
+  let dx = 0;
+  let dy = 0;
+  if (x < r && y < r) {
+    dx = r - x;
+    dy = r - y;
+  } else if (x > maxIndex - r && y < r) {
+    dx = x - (maxIndex - r);
+    dy = r - y;
+  } else if (x < r && y > maxIndex - r) {
+    dx = r - x;
+    dy = y - (maxIndex - r);
+  } else if (x > maxIndex - r && y > maxIndex - r) {
+    dx = x - (maxIndex - r);
+    dy = y - (maxIndex - r);
+  } else {
+    return true;
+  }
+  return dx * dx + dy * dy <= r * r;
+}
+
+function generatePixel(size, x, y) {
+  if (!insideRoundedRect(x, y, size, Math.round(size * 0.22))) {
+    return [0, 0, 0, 0];
+  }
+  const xf = x / (size - 1);
+  const yf = y / (size - 1);
+  const diag = (xf + (1 - yf)) / 2;
+  let color = sampleGradient(bgStops, diag);
+
+  // radial glow
+  const glowCenterX = 0.5;
+  const glowCenterY = 0.43;
+  const dx = xf - glowCenterX;
+  const dy = yf - glowCenterY;
+  const distance = Math.sqrt(dx * dx + dy * dy);
+  const glowStrength = Math.max(0, 1 - Math.pow(distance / 0.7, 2));
+  if (glowStrength > 0) {
+    color = blend(color, glowColor, 0.35 * glowStrength);
+  }
+
+  // wave body
+  const topWave = 0.40 + 0.08 * Math.cos((xf - 0.3) * Math.PI);
+  const bottomWave = 0.78 - 0.1 * Math.cos((xf - 0.3) * Math.PI);
+  if (yf >= topWave && yf <= bottomWave) {
+    const waveT = Math.min(1, Math.max(0, (yf - topWave) / (bottomWave - topWave)));
+    const gradientT = Math.min(1, Math.max(0, (xf - 0.1) / 0.8));
+    const waveColor = sampleGradient(waveStops, gradientT);
+    const depthShade = blend(waveColor, shadowColor, 0.35 * waveT);
+    color = blend(color, depthShade, 0.75);
+  } else if (yf > bottomWave) {
+    color = blend(color, shadowColor, 0.25);
+  }
+
+  // waveform bars
+  const barDefinitions = [
+    { x: 0.26, top: 0.30, bottom: 0.76 },
+    { x: 0.40, top: 0.34, bottom: 0.82 },
+    { x: 0.54, top: 0.32, bottom: 0.80 },
+    { x: 0.68, top: 0.36, bottom: 0.84 },
+  ];
+  const barWidth = 0.06;
+  for (const bar of barDefinitions) {
+    const distanceX = Math.abs(xf - bar.x);
+    if (distanceX <= barWidth / 2 && yf >= bar.top && yf <= bar.bottom) {
+      const fade = 1 - (distanceX / (barWidth / 2));
+      const heightFactor = 1 - Math.min(1, (yf - bar.top) / (bar.bottom - bar.top));
+      const highlight = blend(barColor, glowColor, 0.1 * heightFactor);
+      color = blend(color, highlight, 0.65 * fade);
+    }
+  }
+
+  // bottom arc highlight
+  if (yf > 0.70 && yf < 0.86) {
+    const arcT = Math.sin(((yf - 0.70) / 0.16) * Math.PI);
+    if (arcT > 0) {
+      color = blend(color, glowColor, 0.12 * arcT);
+    }
+  }
+
+  // accent circles
+  const circleDx = xf - 0.5;
+  const circleDy = yf - 0.32;
+  const circleDistance = Math.sqrt(circleDx * circleDx + circleDy * circleDy);
+  if (circleDistance < 0.06) {
+    color = blend(color, accentInner, 0.9);
+  } else if (circleDistance < 0.11) {
+    const ringT = 1 - (circleDistance - 0.06) / (0.11 - 0.06);
+    color = blend(color, accentOuter, 0.5 * ringT);
+  }
+
+  return [color[0], color[1], color[2], 255];
+}
+
+function renderIcon(size) {
+  const buffer = Buffer.alloc(size * size * 4);
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const [r, g, b, a] = generatePixel(size, x, y);
+      const index = (y * size + x) * 4;
+      buffer[index] = r;
+      buffer[index + 1] = g;
+      buffer[index + 2] = b;
+      buffer[index + 3] = a;
+    }
+  }
+  return buffer;
+}
+
+function generateFallbackPngs(outputDir, sizes = [16, 24, 32, 48, 64, 128, 256, 512, 1024]) {
+  fs.mkdirSync(outputDir, { recursive: true });
+  for (const size of sizes) {
+    const pixels = renderIcon(size);
+    const png = createPng(size, size, pixels);
+    fs.writeFileSync(path.join(outputDir, `icon-${size}.png`), png);
+  }
+}
+
+module.exports = {
+  generateFallbackPngs,
+};


### PR DESCRIPTION
## Summary
- add a new vector UDIO Prompt Crafter application icon
- extend the build pipeline to validate SVG icons, rasterise them, and generate platform-specific assets with fallbacks
- point Electron Builder to the generated icon bundle and document the automated icon workflow

## Testing
- node esbuild.config.js

------
https://chatgpt.com/codex/tasks/task_e_68de99062cf88332b6734d85aaaa8492