### PR TITLE
Add keyboard navigation hook for list components

### DIFF
--- a/components/CategoryList.tsx
+++ b/components/CategoryList.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import type { Category, Tag } from '../types';
 import { Icon } from './icons';
 import { Tooltip } from './Tooltip';
+import { useListKeyboardNavigation } from '../hooks/useListKeyboardNavigation';
 
 interface CategoryListProps {
   categories: Category[];
@@ -46,6 +47,15 @@ export const CategoryList: React.FC<CategoryListProps> = ({
 }) => {
   const [draggedItemId, setDraggedItemId] = useState<string | null>(null);
 
+  const { listProps, getItemProps } = useListKeyboardNavigation({
+    items: categories,
+    getId: category => category.id,
+    activeId: activeCategoryId,
+    onSelect: (category) => onSelectCategory(category.id),
+  });
+
+  const focusRingClasses = 'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2';
+
   const handleDragStart = (e: React.DragEvent<HTMLLIElement>, id: string) => {
     setDraggedItemId(id);
     e.dataTransfer.effectAllowed = 'move';
@@ -77,25 +87,25 @@ export const CategoryList: React.FC<CategoryListProps> = ({
   return (
     <nav className="p-4 bg-bunker-50/50 dark:bg-bunker-900/50 text-bunker-500 dark:text-bunker-300 h-full overflow-y-auto">
       <h2 className="text-lg font-semibold mb-4 px-2 text-bunker-900 dark:text-white">Categories</h2>
-      <ul>
-        {categories.map((category) => {
+      <ul {...listProps}>
+        {categories.map((category, index) => {
           const isActive = activeCategoryId === category.id;
-          
+
           const activeClasses = activeColorClasses[category.color || 'gray'];
           const inactiveClasses = `${category.color ? inactiveColorClasses[category.color] : 'border-transparent'} hover:bg-bunker-100 dark:hover:bg-bunker-800/50`;
-          
+
           return (
             <li
               key={category.id}
               draggable
+              {...getItemProps(category, index)}
               onDragStart={(e) => handleDragStart(e, category.id)}
               onDragOver={handleDragOver}
               onDrop={(e) => handleDrop(e, category.id)}
               onDragEnd={handleDragEnd}
-              onClick={() => onSelectCategory(category.id)}
               className={`group flex items-center justify-between pl-3 pr-2 py-2 rounded-r-lg cursor-pointer transition-all duration-200 mb-1 border-l-4 ${
                 isActive ? activeClasses : inactiveClasses
-              } ${draggedItemId === category.id ? 'opacity-50 scale-95' : ''}`}
+              } ${draggedItemId === category.id ? 'opacity-50 scale-95' : ''} ${focusRingClasses}`}
             >
               <div className="flex items-center">
                 <Icon name="grip" className={`w-5 h-5 mr-2 transition-opacity duration-200 ${isActive ? 'opacity-60' : 'text-bunker-300 dark:text-bunker-600 opacity-0 group-hover:opacity-100'} cursor-grab`} />

--- a/components/TaxonomyEditor.tsx
+++ b/components/TaxonomyEditor.tsx
@@ -5,6 +5,7 @@ import { produce } from 'immer';
 import { CategoryEditModal } from './CategoryEditModal';
 import { TagEditor } from './TagEditor';
 import { ConfirmationModal } from './ConfirmationModal';
+import { useListKeyboardNavigation } from '../hooks/useListKeyboardNavigation';
 
 interface TaxonomyEditorProps {
   taxonomy: Taxonomy;
@@ -141,6 +142,18 @@ export const TaxonomyEditor: React.FC<TaxonomyEditorProps> = ({ taxonomy, onSave
   // Drag state for tags
   const [draggedTagId, setDraggedTagId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<{ id: string; position: 'top' | 'bottom' | 'on' } | null>(null);
+
+  const { listProps: categoryListProps, getItemProps: getCategoryItemProps } = useListKeyboardNavigation({
+    items: editedTaxonomy,
+    getId: category => category.id,
+    activeId: selectedCategoryId,
+    onSelect: (category) => {
+      setSelectedCategoryId(category.id);
+      setEditingTag(null);
+    },
+  });
+
+  const categoryFocusRingClasses = 'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2';
 
   useEffect(() => {
     setEditedTaxonomy(JSON.parse(JSON.stringify(taxonomy)));
@@ -439,10 +452,18 @@ export const TaxonomyEditor: React.FC<TaxonomyEditorProps> = ({ taxonomy, onSave
       <div className="p-4 flex space-x-4 flex-grow min-h-0">
         <div className="w-1/3 flex flex-col">
           <h4 className="font-semibold mb-2 px-2 flex-shrink-0">Categories</h4>
-          <ul className="flex-grow space-y-1 pr-2 overflow-y-auto">
-            {editedTaxonomy.map(cat => (
-              <li key={cat.id} onClick={() => { setSelectedCategoryId(cat.id); setEditingTag(null); }} draggable onDragStart={() => setDraggedCategory(cat.id)} onDragOver={(e) => e.preventDefault()} onDrop={() => handleDropCategory(cat.id)} onDragEnd={() => setDraggedCategory(null)}
-                className={`group flex justify-between items-center p-2 rounded-md cursor-pointer transition-all ${selectedCategoryId === cat.id ? 'bg-blue-600 text-white shadow-sm' : 'hover:bg-bunker-100 dark:hover:bg-bunker-800'} ${draggedCategory === cat.id ? 'opacity-30' : ''}`}>
+          <ul {...categoryListProps} className="flex-grow space-y-1 pr-2 overflow-y-auto">
+            {editedTaxonomy.map((cat, index) => (
+              <li
+                key={cat.id}
+                draggable
+                {...getCategoryItemProps(cat, index)}
+                onDragStart={() => setDraggedCategory(cat.id)}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={() => handleDropCategory(cat.id)}
+                onDragEnd={() => setDraggedCategory(null)}
+                className={`group flex justify-between items-center p-2 rounded-md cursor-pointer transition-all ${selectedCategoryId === cat.id ? 'bg-blue-600 text-white shadow-sm' : 'hover:bg-bunker-100 dark:hover:bg-bunker-800'} ${draggedCategory === cat.id ? 'opacity-30' : ''} ${categoryFocusRingClasses}`}
+              >
                 <div className="flex items-center">
                   <Icon name="grip" className="w-5 h-5 mr-2 text-bunker-400 dark:text-bunker-500 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab" />
                   <span>{cat.name}</span>

--- a/hooks/useListKeyboardNavigation.ts
+++ b/hooks/useListKeyboardNavigation.ts
@@ -1,0 +1,186 @@
+import type { HTMLAttributes, KeyboardEvent, MouseEventHandler } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+interface UseListKeyboardNavigationOptions<T> {
+  items: T[];
+  getId: (item: T) => string;
+  activeId?: string | null;
+  onSelect?: (item: T, index: number) => void;
+}
+
+interface GetItemPropsOptions {
+  onClick?: MouseEventHandler<HTMLElement>;
+}
+
+interface UseListKeyboardNavigationResult<T> {
+  listProps: HTMLAttributes<HTMLUListElement>;
+  getItemProps: (
+    item: T,
+    index: number,
+    options?: GetItemPropsOptions
+  ) => HTMLAttributes<HTMLElement> & {
+    ref: (element: HTMLElement | null) => void;
+  };
+  activeIndex: number;
+}
+
+export const useListKeyboardNavigation = <T,>({
+  items,
+  getId,
+  activeId,
+  onSelect,
+}: UseListKeyboardNavigationOptions<T>): UseListKeyboardNavigationResult<T> => {
+  const itemRefs = useRef<Array<HTMLElement | null>>([]);
+  const [focusedIndex, setFocusedIndex] = useState(() => {
+    if (!items.length) return -1;
+    if (activeId) {
+      const activeIndex = items.findIndex(item => getId(item) === activeId);
+      if (activeIndex !== -1) {
+        return activeIndex;
+      }
+    }
+    return 0;
+  });
+
+  const activeIndex = useMemo(() => {
+    if (!activeId) return -1;
+    return items.findIndex(item => getId(item) === activeId);
+  }, [items, getId, activeId]);
+
+  useEffect(() => {
+    itemRefs.current = itemRefs.current.slice(0, items.length);
+  }, [items.length]);
+
+  useEffect(() => {
+    if (!items.length) {
+      setFocusedIndex(-1);
+      return;
+    }
+
+    if (activeIndex !== -1) {
+      setFocusedIndex(activeIndex);
+      return;
+    }
+
+    setFocusedIndex(prev => {
+      if (prev >= 0 && prev < items.length) {
+        return prev;
+      }
+      return 0;
+    });
+  }, [items, activeIndex]);
+
+  const focusItem = useCallback((index: number) => {
+    const element = itemRefs.current[index];
+    if (element) {
+      element.focus();
+    }
+  }, []);
+
+  const moveFocus = useCallback(
+    (index: number) => {
+      if (!items.length) return;
+      const clampedIndex = Math.min(Math.max(index, 0), items.length - 1);
+      setFocusedIndex(clampedIndex);
+      const schedule = () => focusItem(clampedIndex);
+      if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(schedule);
+      } else {
+        setTimeout(schedule, 0);
+      }
+    },
+    [items.length, focusItem]
+  );
+
+  const handleItemSelect = useCallback(
+    (index: number) => {
+      if (index < 0 || index >= items.length) return;
+      setFocusedIndex(index);
+      const element = itemRefs.current[index];
+      if (element) {
+        element.focus();
+      }
+      onSelect?.(items[index], index);
+    },
+    [items, onSelect]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>, index: number) => {
+      if (!items.length) return;
+
+      switch (event.key) {
+        case 'ArrowDown':
+        case 'ArrowRight':
+          event.preventDefault();
+          moveFocus(index + 1);
+          break;
+        case 'ArrowUp':
+        case 'ArrowLeft':
+          event.preventDefault();
+          moveFocus(index - 1);
+          break;
+        case 'Home':
+        case 'PageUp':
+          event.preventDefault();
+          moveFocus(0);
+          break;
+        case 'End':
+        case 'PageDown':
+          event.preventDefault();
+          moveFocus(items.length - 1);
+          break;
+        case 'Enter':
+        case ' ': // Space
+          event.preventDefault();
+          handleItemSelect(index);
+          break;
+        default:
+          break;
+      }
+    },
+    [items.length, moveFocus, handleItemSelect]
+  );
+
+  const listProps = useMemo<HTMLAttributes<HTMLUListElement>>(
+    () => ({
+      role: 'listbox',
+      'aria-orientation': 'vertical',
+    }),
+    []
+  );
+
+  const getItemProps = useCallback<
+    UseListKeyboardNavigationResult<T>['getItemProps']
+  >(
+    (item, index, options) => {
+      const { onClick } = options || {};
+      const id = getId(item);
+      const isActive = activeId ? id === activeId : index === focusedIndex;
+
+      return {
+        ref: (element: HTMLElement | null) => {
+          itemRefs.current[index] = element;
+        },
+        tabIndex: index === focusedIndex ? 0 : -1,
+        role: 'option',
+        'aria-selected': isActive,
+        onFocus: () => setFocusedIndex(index),
+        onKeyDown: event => handleKeyDown(event, index),
+        onClick: event => {
+          onClick?.(event);
+          if (!event.defaultPrevented) {
+            handleItemSelect(index);
+          }
+        },
+      };
+    },
+    [activeId, focusedIndex, getId, handleItemSelect, handleKeyDown]
+  );
+
+  return {
+    listProps,
+    getItemProps,
+    activeIndex: focusedIndex,
+  };
+};


### PR DESCRIPTION
## Summary
- add a reusable `useListKeyboardNavigation` hook that provides arrow, page, home/end, and enter/space handling for list items
- apply the hook to the main category list and taxonomy editor categories to enable consistent keyboard navigation with visible focus rings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deb99fc9788332a0ffd26ee77bc4c1