### PR TITLE
Adjust keyboard list focus handling

### DIFF
--- a/components/CategoryList.tsx
+++ b/components/CategoryList.tsx
@@ -54,7 +54,7 @@ export const CategoryList: React.FC<CategoryListProps> = ({
     onSelect: (category) => onSelectCategory(category.id),
   });
 
-  const focusRingClasses = 'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2';
+  const focusRingClasses = 'focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus:ring-0';
 
   const handleDragStart = (e: React.DragEvent<HTMLLIElement>, id: string) => {
     setDraggedItemId(id);

--- a/components/TaxonomyEditor.tsx
+++ b/components/TaxonomyEditor.tsx
@@ -153,7 +153,7 @@ export const TaxonomyEditor: React.FC<TaxonomyEditorProps> = ({ taxonomy, onSave
     },
   });
 
-  const categoryFocusRingClasses = 'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2';
+  const categoryFocusRingClasses = 'focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus:ring-0';
 
   useEffect(() => {
     setEditedTaxonomy(JSON.parse(JSON.stringify(taxonomy)));

--- a/hooks/useListKeyboardNavigation.ts
+++ b/hooks/useListKeyboardNavigation.ts
@@ -73,7 +73,7 @@ export const useListKeyboardNavigation = <T,>({
   const focusItem = useCallback((index: number) => {
     const element = itemRefs.current[index];
     if (element) {
-      element.focus();
+      element.focus({ preventScroll: true });
     }
   }, []);
 
@@ -98,7 +98,7 @@ export const useListKeyboardNavigation = <T,>({
       setFocusedIndex(index);
       const element = itemRefs.current[index];
       if (element) {
-        element.focus();
+        element.focus({ preventScroll: true });
       }
       onSelect?.(items[index], index);
     },


### PR DESCRIPTION
## Summary
- remove the visible focus ring styling from category and taxonomy list items so keyboard navigation no longer shows a selection rectangle
- keep programmatic focus changes when navigating with the keyboard while preventing unwanted scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68debe6b33588332b70de69043334d1f