### PR TITLE
Align list selection with focus

### DIFF
--- a/components/InfoPage.tsx
+++ b/components/InfoPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { logger } from '../utils/logger';
 import { MarkdownViewer } from './MarkdownViewer';
+import { useListKeyboardNavigation } from '../hooks/useListKeyboardNavigation';
 
 const isElectron = !!window.electronAPI;
 
@@ -16,6 +17,13 @@ export const InfoPage: React.FC = () => {
   const [content, setContent] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const { listProps, getItemProps } = useListKeyboardNavigation({
+    items: DOCS,
+    getId: doc => doc.id,
+    activeId: activeDoc.id,
+    onSelect: doc => setActiveDoc(doc),
+  });
 
   useEffect(() => {
     const loadContent = async () => {
@@ -53,12 +61,15 @@ export const InfoPage: React.FC = () => {
     <div className="flex h-full bg-white dark:bg-bunker-900">
       <nav className="w-64 border-r border-bunker-200 dark:border-bunker-800 p-4 shrink-0 bg-bunker-50/50 dark:bg-bunker-900/50">
         <h2 className="text-lg font-semibold mb-4 text-bunker-900 dark:text-white px-2">Information</h2>
-        <ul className="space-y-1">
-          {DOCS.map(doc => (
+        <ul className="space-y-1" {...listProps}>
+          {DOCS.map((doc, index) => (
             <li key={doc.id}>
               <button
-                onClick={() => setActiveDoc(doc)}
-                className={`w-full text-left ${navButtonStyles} ${activeDoc.id === doc.id ? activeNavStyles : inactiveNavStyles}`}
+                type="button"
+                {...getItemProps(doc, index, {
+                  onClick: () => setActiveDoc(doc),
+                })}
+                className={`w-full text-left ${navButtonStyles} ${activeDoc.id === doc.id ? activeNavStyles : inactiveNavStyles} focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500`}
               >
                 {doc.title}
               </button>

--- a/hooks/useListKeyboardNavigation.ts
+++ b/hooks/useListKeyboardNavigation.ts
@@ -70,28 +70,6 @@ export const useListKeyboardNavigation = <T,>({
     });
   }, [items, activeIndex]);
 
-  const focusItem = useCallback((index: number) => {
-    const element = itemRefs.current[index];
-    if (element) {
-      element.focus({ preventScroll: true });
-    }
-  }, []);
-
-  const moveFocus = useCallback(
-    (index: number) => {
-      if (!items.length) return;
-      const clampedIndex = Math.min(Math.max(index, 0), items.length - 1);
-      setFocusedIndex(clampedIndex);
-      const schedule = () => focusItem(clampedIndex);
-      if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
-        window.requestAnimationFrame(schedule);
-      } else {
-        setTimeout(schedule, 0);
-      }
-    },
-    [items.length, focusItem]
-  );
-
   const handleItemSelect = useCallback(
     (index: number) => {
       if (index < 0 || index >= items.length) return;
@@ -113,22 +91,22 @@ export const useListKeyboardNavigation = <T,>({
         case 'ArrowDown':
         case 'ArrowRight':
           event.preventDefault();
-          moveFocus(index + 1);
+          handleItemSelect(Math.min(index + 1, items.length - 1));
           break;
         case 'ArrowUp':
         case 'ArrowLeft':
           event.preventDefault();
-          moveFocus(index - 1);
+          handleItemSelect(Math.max(index - 1, 0));
           break;
         case 'Home':
         case 'PageUp':
           event.preventDefault();
-          moveFocus(0);
+          handleItemSelect(0);
           break;
         case 'End':
         case 'PageDown':
           event.preventDefault();
-          moveFocus(items.length - 1);
+          handleItemSelect(items.length - 1);
           break;
         case 'Enter':
         case ' ': // Space
@@ -139,7 +117,7 @@ export const useListKeyboardNavigation = <T,>({
           break;
       }
     },
-    [items.length, moveFocus, handleItemSelect]
+    [items.length, handleItemSelect]
   );
 
   const listProps = useMemo<HTMLAttributes<HTMLUListElement>>(


### PR DESCRIPTION
## Summary
- update the shared list navigation hook so arrow keys move the active selection together with focus
- adopt the keyboard navigation hook for the info and settings sidebars and add consistent focus styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0dbcc8da88332a1e9236e98bfd571