### PR TITLE
Improve active preset editing workflow

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import type { Preset } from '../types';
 import { Icon } from './icons';
 import { Tooltip } from './Tooltip';
 
@@ -9,13 +8,16 @@ interface HeaderProps {
   onSetView: (view: 'crafter' | 'settings' | 'info' | 'presets') => void;
   onToggleTheme: () => void;
   onOpenSavePresetModal: () => void;
-  onOpenPresetManagerModal: () => void;
   onOpenHistoryModal: () => void;
   onOpenDeconstructModal: () => void;
   onOpenThematicRandomizerModal: () => void;
   onClear: () => void;
   onOpenCommandPalette: () => void;
   onToggleLogPanel: () => void;
+  loadedPresetName: string | null;
+  hasActivePresetChanges: boolean;
+  onUpdateActivePreset: () => void;
+  onSaveActivePresetAsNew: () => void;
 }
 
 const HeaderButton: React.FC<{onClick: () => void; title: string; icon: string; children?: React.ReactNode; className?: string;}> = ({onClick, title, icon, children, className=""}) => (
@@ -30,19 +32,22 @@ const HeaderButton: React.FC<{onClick: () => void; title: string; icon: string; 
     </Tooltip>
 );
 
-export const Header: React.FC<HeaderProps> = ({ 
-    theme, 
-    activeView, 
-    onSetView, 
-    onToggleTheme, 
-    onOpenSavePresetModal, 
-    onOpenPresetManagerModal, 
+export const Header: React.FC<HeaderProps> = ({
+    theme,
+    activeView,
+    onSetView,
+    onToggleTheme,
+    onOpenSavePresetModal,
     onOpenHistoryModal,
     onOpenDeconstructModal,
-    onOpenThematicRandomizerModal, 
-    onClear, 
-    onOpenCommandPalette, 
-    onToggleLogPanel 
+    onOpenThematicRandomizerModal,
+    onClear,
+    onOpenCommandPalette,
+    onToggleLogPanel,
+    loadedPresetName,
+    hasActivePresetChanges,
+    onUpdateActivePreset,
+    onSaveActivePresetAsNew
 }) => {
   
   const tabButtonStyles = "px-3 py-1.5 rounded-md text-sm font-medium transition-colors";
@@ -51,7 +56,7 @@ export const Header: React.FC<HeaderProps> = ({
 
   return (
     <header className="bg-white/80 dark:bg-bunker-950/80 backdrop-blur-sm text-bunker-900 dark:text-white p-3 flex items-center justify-between border-b border-bunker-200/80 dark:border-bunker-800/80 shrink-0">
-      <div className="flex items-center">
+      <div className="flex items-center space-x-4">
           <nav className="flex items-center space-x-1 p-1 bg-bunker-100 dark:bg-bunker-800/80 rounded-lg">
               <button onClick={() => onSetView('crafter')} className={`${tabButtonStyles} ${activeView === 'crafter' ? activeTabStyles : inactiveTabStyles}`}>
                   Crafter
@@ -66,13 +71,63 @@ export const Header: React.FC<HeaderProps> = ({
                   Info
               </button>
           </nav>
+          {loadedPresetName && (
+              <div className="flex flex-col sm:flex-row sm:items-center gap-3 px-3 py-2 bg-blue-50 dark:bg-blue-500/20 text-blue-700 dark:text-blue-200 rounded-lg border border-blue-200/60 dark:border-blue-500/50 shadow-sm">
+                  <div className="flex items-start gap-2 min-w-0">
+                      <Icon name="tag" className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                      <div className="min-w-0">
+                          <p className="text-[11px] uppercase tracking-wide text-blue-600/80 dark:text-blue-200/70">
+                              {hasActivePresetChanges ? 'Preset modified' : 'Active preset'}
+                          </p>
+                          <span className="block text-xs sm:text-sm font-semibold truncate" title={loadedPresetName}>
+                              {loadedPresetName}
+                          </span>
+                          {hasActivePresetChanges && (
+                              <p className="mt-1 text-[11px] font-medium text-blue-500/80 dark:text-blue-200/80">
+                                  Unsaved changes
+                              </p>
+                          )}
+                      </div>
+                  </div>
+                  <div className="flex items-center flex-wrap gap-2">
+                      {hasActivePresetChanges ? (
+                          <>
+                              <button
+                                type="button"
+                                onClick={onUpdateActivePreset}
+                                className="inline-flex items-center gap-1 rounded-md bg-blue-600 text-white px-3 py-1.5 text-xs sm:text-sm font-medium shadow-sm hover:bg-blue-700 transition-colors"
+                              >
+                                <Icon name="check" className="w-4 h-4" />
+                                <span>Update preset</span>
+                              </button>
+                              <button
+                                type="button"
+                                onClick={onSaveActivePresetAsNew}
+                                className="inline-flex items-center gap-1 rounded-md border border-blue-300/60 px-3 py-1.5 text-xs sm:text-sm font-medium text-blue-700 hover:bg-blue-100/80 dark:text-blue-200 dark:border-blue-500/60 dark:hover:bg-blue-500/10 transition-colors"
+                              >
+                                <Icon name="copy" className="w-4 h-4" />
+                                <span>Save as new</span>
+                              </button>
+                          </>
+                      ) : (
+                          <button
+                            type="button"
+                            onClick={onSaveActivePresetAsNew}
+                            className="inline-flex items-center gap-1 rounded-md border border-blue-300/60 px-3 py-1.5 text-xs sm:text-sm font-medium text-blue-700 hover:bg-blue-100/80 dark:text-blue-200 dark:border-blue-500/60 dark:hover:bg-blue-500/10 transition-colors"
+                          >
+                            <Icon name="copy" className="w-4 h-4" />
+                            <span>Save a copy</span>
+                          </button>
+                      )}
+                  </div>
+              </div>
+          )}
       </div>
 
       <div className="flex items-center space-x-2">
         {activeView === 'crafter' && (
             <>
                 <HeaderButton onClick={onOpenHistoryModal} title="Prompt History" icon="history" />
-                <HeaderButton onClick={onOpenPresetManagerModal} title="Manage Presets" icon="list-bullet" />
                 <HeaderButton onClick={onOpenSavePresetModal} title="Save Current as Preset..." icon="save" />
                 <HeaderButton onClick={onOpenDeconstructModal} title="Deconstruct Prompt with AI" icon="wandSparkles" />
                 <HeaderButton onClick={onOpenThematicRandomizerModal} title="Thematic Randomizer" icon="sparkles" />

--- a/components/SavePresetModal.tsx
+++ b/components/SavePresetModal.tsx
@@ -13,6 +13,8 @@ interface SavePresetModalProps {
   orderedCategories: Category[];
   taxonomy: Taxonomy;
   callLlm: (systemPrompt: string, userPrompt: string, isResponseTextFreeform?: boolean) => Promise<any>;
+  initialName?: string;
+  initialDescription?: string;
 }
 
 const LoadingSpinner: React.FC<{className?: string}> = ({className = 'h-4 w-4'}) => (
@@ -23,14 +25,16 @@ const LoadingSpinner: React.FC<{className?: string}> = ({className = 'h-4 w-4'})
 );
 
 
-export const SavePresetModal: React.FC<SavePresetModalProps> = ({ 
-    isOpen, 
-    onClose, 
-    onSave, 
-    selectedTags, 
-    textCategoryValues, 
-    orderedCategories, 
-    callLlm 
+export const SavePresetModal: React.FC<SavePresetModalProps> = ({
+    isOpen,
+    onClose,
+    onSave,
+    selectedTags,
+    textCategoryValues,
+    orderedCategories,
+    callLlm,
+    initialName,
+    initialDescription
 }) => {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -40,12 +44,12 @@ export const SavePresetModal: React.FC<SavePresetModalProps> = ({
 
   useEffect(() => {
     if (isOpen) {
-      setName('');
-      setDescription('');
+      setName(initialName || '');
+      setDescription(initialDescription || '');
       setAiTitles([]);
       setGenerationError(null);
     }
-  }, [isOpen]);
+  }, [isOpen, initialName, initialDescription]);
 
   const handleSave = () => {
     if (onSave(name.trim(), description.trim())) {


### PR DESCRIPTION
## Summary
- track a snapshot of the active preset so edits surface unsaved changes and can be written back to the original preset
- expand the header callout with update/save-as-new actions to streamline enhancing a loaded preset
- allow the save preset modal to open with suggested names and descriptions when duplicating presets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f4eb3cbaf483329f46db29425ced30