### PR TITLE
Enhance active preset editing workflow

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,13 +8,15 @@ interface HeaderProps {
   onSetView: (view: 'crafter' | 'settings' | 'info' | 'presets') => void;
   onToggleTheme: () => void;
   onOpenSavePresetModal: () => void;
+  onSaveActivePresetAsNew: () => void;
+  onUpdateActivePreset: () => void;
   onOpenHistoryModal: () => void;
   onOpenDeconstructModal: () => void;
   onOpenThematicRandomizerModal: () => void;
   onClear: () => void;
   onOpenCommandPalette: () => void;
   onToggleLogPanel: () => void;
-  loadedPresetName: string | null;
+  activePreset: { name: string; isDirty: boolean } | null;
 }
 
 const HeaderButton: React.FC<{onClick: () => void; title: string; icon: string; children?: React.ReactNode; className?: string;}> = ({onClick, title, icon, children, className=""}) => (
@@ -35,18 +37,25 @@ export const Header: React.FC<HeaderProps> = ({
     onSetView,
     onToggleTheme,
     onOpenSavePresetModal,
+    onSaveActivePresetAsNew,
+    onUpdateActivePreset,
     onOpenHistoryModal,
     onOpenDeconstructModal,
     onOpenThematicRandomizerModal,
     onClear,
     onOpenCommandPalette,
     onToggleLogPanel,
-    loadedPresetName
+    activePreset
 }) => {
-  
+
   const tabButtonStyles = "px-3 py-1.5 rounded-md text-sm font-medium transition-colors";
   const activeTabStyles = "bg-blue-600 text-white shadow-sm";
   const inactiveTabStyles = "text-bunker-500 dark:text-bunker-400 hover:bg-white/60 dark:hover:bg-bunker-700/50";
+  const presetHighlightClasses = activePreset
+    ? activePreset.isDirty
+      ? 'bg-amber-50 border-amber-200 text-amber-700 dark:bg-amber-500/10 dark:border-amber-400/40 dark:text-amber-200'
+      : 'bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-500/10 dark:border-blue-400/40 dark:text-blue-200'
+    : '';
 
   return (
     <header className="bg-white/80 dark:bg-bunker-950/80 backdrop-blur-sm text-bunker-900 dark:text-white p-3 flex items-center justify-between border-b border-bunker-200/80 dark:border-bunker-800/80 shrink-0">
@@ -61,20 +70,45 @@ export const Header: React.FC<HeaderProps> = ({
               <button onClick={() => onSetView('settings')} className={`${tabButtonStyles} ${activeView === 'settings' ? activeTabStyles : inactiveTabStyles}`}>
                   Settings
               </button>
-               <button onClick={() => onSetView('info')} className={`${tabButtonStyles} ${activeView === 'info' ? activeTabStyles : inactiveTabStyles}`}>
+              <button onClick={() => onSetView('info')} className={`${tabButtonStyles} ${activeView === 'info' ? activeTabStyles : inactiveTabStyles}`}>
                   Info
               </button>
           </nav>
-          {loadedPresetName && (
-              <div className="flex items-center space-x-2 px-3 py-1.5 bg-blue-50 dark:bg-blue-500/20 text-blue-700 dark:text-blue-200 rounded-lg max-w-[11rem] sm:max-w-[14rem]">
-                  <Icon name="bookmark" className="w-4 h-4 flex-shrink-0" />
-                  <div className="min-w-0">
-                      <p className="text-[11px] uppercase tracking-wide text-blue-600/80 dark:text-blue-200/80">Active Preset</p>
-                      <span className="block text-xs sm:text-sm font-medium truncate" title={loadedPresetName}>
-                          {loadedPresetName}
-                      </span>
-                  </div>
+          {activePreset && (
+            <div
+              className={`flex items-center gap-3 px-3 py-1.5 rounded-lg border ${presetHighlightClasses} flex-wrap sm:flex-nowrap`}
+            >
+              <Icon name="bookmark" className="w-4 h-4 flex-shrink-0" />
+              <div className="min-w-0">
+                <p className="text-[11px] uppercase tracking-wide opacity-80">Active Preset</p>
+                <span className="block text-xs sm:text-sm font-medium truncate max-w-[10rem] sm:max-w-[12rem]" title={activePreset.name}>
+                  {activePreset.name}
+                </span>
               </div>
+              <div className="flex items-center gap-2 ml-auto">
+                <span className={`text-[11px] font-semibold uppercase tracking-wide ${activePreset.isDirty ? 'text-amber-600 dark:text-amber-200' : 'text-blue-600 dark:text-blue-200'}`}>
+                  {activePreset.isDirty ? 'Modified' : 'In Sync'}
+                </span>
+                {activePreset.isDirty && (
+                  <Tooltip text="Update this preset with your current settings">
+                    <button
+                      onClick={onUpdateActivePreset}
+                      className="px-2 py-1 text-xs font-semibold rounded-md bg-amber-500 text-white hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-offset-white dark:focus:ring-offset-bunker-900 focus:ring-amber-400 transition-colors"
+                    >
+                      Update
+                    </button>
+                  </Tooltip>
+                )}
+                <Tooltip text="Save these settings as a brand new preset">
+                  <button
+                    onClick={onSaveActivePresetAsNew}
+                    className="px-2 py-1 text-xs font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-offset-white dark:focus:ring-offset-bunker-900 focus:ring-blue-400 transition-colors"
+                  >
+                    Save as New
+                  </button>
+                </Tooltip>
+              </div>
+            </div>
           )}
       </div>
 

--- a/components/SavePresetModal.tsx
+++ b/components/SavePresetModal.tsx
@@ -13,6 +13,9 @@ interface SavePresetModalProps {
   orderedCategories: Category[];
   taxonomy: Taxonomy;
   callLlm: (systemPrompt: string, userPrompt: string, isResponseTextFreeform?: boolean) => Promise<any>;
+  initialName?: string;
+  initialDescription?: string;
+  basePresetName?: string;
 }
 
 const LoadingSpinner: React.FC<{className?: string}> = ({className = 'h-4 w-4'}) => (
@@ -23,14 +26,17 @@ const LoadingSpinner: React.FC<{className?: string}> = ({className = 'h-4 w-4'})
 );
 
 
-export const SavePresetModal: React.FC<SavePresetModalProps> = ({ 
-    isOpen, 
-    onClose, 
-    onSave, 
-    selectedTags, 
-    textCategoryValues, 
-    orderedCategories, 
-    callLlm 
+export const SavePresetModal: React.FC<SavePresetModalProps> = ({
+    isOpen,
+    onClose,
+    onSave,
+    selectedTags,
+    textCategoryValues,
+    orderedCategories,
+    callLlm,
+    initialName,
+    initialDescription,
+    basePresetName
 }) => {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -40,12 +46,12 @@ export const SavePresetModal: React.FC<SavePresetModalProps> = ({
 
   useEffect(() => {
     if (isOpen) {
-      setName('');
-      setDescription('');
+      setName(initialName ?? '');
+      setDescription(initialDescription ?? '');
       setAiTitles([]);
       setGenerationError(null);
     }
-  }, [isOpen]);
+  }, [isOpen, initialName, initialDescription]);
 
   const handleSave = () => {
     if (onSave(name.trim(), description.trim())) {
@@ -120,6 +126,12 @@ export const SavePresetModal: React.FC<SavePresetModalProps> = ({
                 <Icon name="x" className="w-5 h-5 text-bunker-500" />
             </button>
         </div>
+        {basePresetName && (
+          <div className="mt-4 px-3 py-2 rounded-md bg-blue-100/70 dark:bg-blue-900/30 text-xs text-blue-700 dark:text-blue-200 flex items-center gap-2">
+            <Icon name="bookmark" className="w-4 h-4" />
+            <span>Based on <span className="font-semibold">{basePresetName}</span>. Rename to create a new preset.</span>
+          </div>
+        )}
         <div className="mt-4 space-y-4">
           <div>
             <label htmlFor="preset-name" className="block text-sm font-medium text-bunker-700 dark:text-bunker-300">


### PR DESCRIPTION
## Summary
- track the currently loaded preset along with a dirty state so edits stay associated with their source
- surface update and "save as new" actions plus modified status directly in the header highlight
- prefill the save preset modal when duplicating a preset and show context about the source preset

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f4fc16ca348332b04dd3f30b19a71f